### PR TITLE
feat: Apply korean translation to wear setup info screen

### DIFF
--- a/K-canvas/src/main/java/com/kaist/k_canvas/CanvasDrawings.kt
+++ b/K-canvas/src/main/java/com/kaist/k_canvas/CanvasDrawings.kt
@@ -168,8 +168,8 @@ class KCanvas {
 
             // Draw info text
             val textBounds = Rect()
-            val info1 = "Requires\nUser Setup"
-            val info2 = "Return to the mobile app\non your smartphone\nto complete setup."
+            val info1 = context.resources.getString(R.string.setup_info_title)
+            val info2 = context.resources.getString(R.string.setup_info_description)
             val info1Paint = KPaint.setupInfoPaint(1, unitF, typeface)
             val info2Paint = KPaint.setupInfoPaint(2, unitF, typeface)
             val info1LineHeight = unitF * 24f

--- a/K-canvas/src/main/res/values-ko/strings.xml
+++ b/K-canvas/src/main/res/values-ko/strings.xml
@@ -1,0 +1,5 @@
+
+<resources>
+    <string name="setup_info_title">사용자 설정 필요</string>
+    <string name="setup_info_description">K-Dual 모바일 앱에서\n설정을 완료해주세요.</string>
+</resources>

--- a/K-canvas/src/main/res/values-ko/strings.xml
+++ b/K-canvas/src/main/res/values-ko/strings.xml
@@ -1,4 +1,3 @@
-
 <resources>
     <string name="setup_info_title">사용자 설정 필요</string>
     <string name="setup_info_description">K-Dual 모바일 앱에서\n설정을 완료해주세요.</string>

--- a/K-canvas/src/main/res/values/strings.xml
+++ b/K-canvas/src/main/res/values/strings.xml
@@ -1,4 +1,3 @@
-
 <resources>
     <string name="setup_info_title">Requires\nUser Setup</string>
     <string name="setup_info_description">Return to the mobile app\non your smartphone\nto complete setup.</string>

--- a/K-canvas/src/main/res/values/strings.xml
+++ b/K-canvas/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+
+<resources>
+    <string name="setup_info_title">Requires\nUser Setup</string>
+    <string name="setup_info_description">Return to the mobile app\non your smartphone\nto complete setup.</string>
+</resources>

--- a/wear/src/main/java/com/kaist/k_dual/watchface/KDualCanvasRenderer.kt
+++ b/wear/src/main/java/com/kaist/k_dual/watchface/KDualCanvasRenderer.kt
@@ -270,7 +270,9 @@ class KDualCanvasRenderer(
     }
 
     override fun onTapEvent(tapType: Int, tapEvent: TapEvent, complicationSlot: ComplicationSlot?) {
-        // For test blink effect
+        if (settings == null) {
+            return
+        }
         if (settings?.enableDualMode == true && tapEvent.yPos > watchRect.height() / 2) {
             if (tapType == TapType.UP) {
                 openWearApp(2)


### PR DESCRIPTION
- K-canvas 라이브러리에 `res/values/strings.xml` 및 `res/values-ko/strings.xml` 생성하여 `CanvasDrawings.kt`에서 사용
- 세팅 안됐을때 워치페이스 탭하면 검은화면 뜨던 현상 해결

### 테스트
Wear 에뮬레이터 언어설정 변경 방법 : https://stackoverflow.com/a/76381212/5952925

<img width="573" alt="image" src="https://github.com/KAISTxKST1D/K-Dual/assets/60031762/0482e604-1260-42d3-b79f-719600b578c9">
<img width="573" alt="image" src="https://github.com/KAISTxKST1D/K-Dual/assets/60031762/c45b24b7-a9a3-4aea-997a-b263054ca498">
