### PR TITLE
bugfix: Prevent decomposition of Korean in name field

### DIFF
--- a/mobile/src/main/java/com/kaist/k_dual/component/TextFieldAlertDialog.kt
+++ b/mobile/src/main/java/com/kaist/k_dual/component/TextFieldAlertDialog.kt
@@ -88,16 +88,25 @@ fun TextFieldAlertDialog(
                             value = textFieldValue,
                             onValueChange = { newValue ->
                                 textFieldValue = if (outlinedInputParameters.maxLength != null) {
-                                    TextFieldValue(
-                                        text = newValue.text.substring(
-                                            0,
-                                            min(
-                                                newValue.text.length,
-                                                outlinedInputParameters.maxLength
-                                            )
-                                        ),
-                                        selection = TextRange(newValue.text.length)
+                                    val trimmedText = newValue.text.substring(
+                                        0,
+                                        min(
+                                            newValue.text.length,
+                                            outlinedInputParameters.maxLength
+                                        )
                                     )
+                                    if (newValue.composition != null) {
+                                        TextFieldValue(
+                                            text = trimmedText,
+                                            selection = TextRange(newValue.selection.start),
+                                            composition = newValue.composition
+                                        )
+                                    } else {
+                                        TextFieldValue(
+                                            text = trimmedText,
+                                            selection = TextRange(newValue.text.length)
+                                        )
+                                    }
                                 } else {
                                     newValue
                                 }


### PR DESCRIPTION
- 문제) TextFieldAlertDialog의 outlinedInputParameters에 maxLength 조건이 있는 경우 한글이 분해되는 버그
- 해결) maxLength TextFieldValue의 composition 속성을 활용해, 조합 언어(ex. 한글)일 경우 커서 위치 조정을 처리함.